### PR TITLE
.github/workflows: add atlas ci workflow

### DIFF
--- a/.github/workflows/ci-atlas.yaml
+++ b/.github/workflows/ci-atlas.yaml
@@ -1,0 +1,65 @@
+name: Atlas
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'another_work/MARIA/migrations/*'
+# Permissions to write comments on the pull request.
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  lint:
+    services:
+      # Spin up a mariadb:11 container to be used as the dev-database for analysis.
+      mariadb:
+        image: mariadb:11
+        env:
+          MYSQL_DATABASE: dev
+          MYSQL_ROOT_PASSWORD: pass
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --su-mysql --connect --innodb_initialized"
+          --health-interval 10s
+          --health-start-period 10s
+          --health-timeout 5s
+          --health-retries 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ariga/atlas-action@v0
+        with:
+          dir: 'another_work/MARIA/migrations'
+          dev-url: 'maria://root:pass@localhost:3306/dev'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN_QFY2QU }}
+  sync:
+    needs: lint
+    services:
+      # Spin up a mariadb:11 container to be used as the dev-database for analysis.
+      mariadb:
+        image: mariadb:11
+        env:
+          MYSQL_DATABASE: dev
+          MYSQL_ROOT_PASSWORD: pass
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --su-mysql --connect --innodb_initialized"
+          --health-interval 10s
+          --health-start-period 10s
+          --health-timeout 5s
+          --health-retries 10
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ariga/atlas-sync-action@v0
+        with:
+          dir: 'another_work/MARIA/migrations'
+          dev-url: 'maria://root:pass@mariadb:3306/dev'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN_QFY2QU }}


### PR DESCRIPTION
PR created by the `gh atlas init-action` command.
 for more information visit https://github.com/ariga/gh-atlas.